### PR TITLE
Add compression support in output plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ Or install it yourself as:
       max_send_retries    (integer)    :default => 3
       required_acks       (integer)    :default => 0
       ack_timeout_ms      (integer)    :default => 1500
+      compression_codec   (none|gzip|snappy) :default => none
     </match>
 
 Supports following Poseidon::Producer options.
@@ -54,6 +55,7 @@ Supports following Poseidon::Producer options.
 - max_send_retries — default: 3 — Number of times to retry sending of messages to a leader.
 - required_acks — default: 0 — The number of acks required per request.
 - ack_timeout_ms — default: 1500 — How long the producer waits for acks.
+- compression_codec - default: none - The codec the producer uses to compress messages.
 
 See also [Poseidon::Producer](http://www.rubydoc.info/github/bpot/poseidon/Poseidon/Producer) for more detailed documentation about Poseidon.
 
@@ -75,6 +77,7 @@ See also [Poseidon::Producer](http://www.rubydoc.info/github/bpot/poseidon/Posei
       max_send_retries    (integer)    :default => 3
       required_acks       (integer)    :default => 0
       ack_timeout_ms      (integer)    :default => 1500
+      compression_codec   (none|gzip|snappy) :default => none
     </match>
 
 Supports following Poseidon::Producer options.
@@ -82,6 +85,7 @@ Supports following Poseidon::Producer options.
 - max_send_retries — default: 3 — Number of times to retry sending of messages to a leader.
 - required_acks — default: 0 — The number of acks required per request.
 - ack_timeout_ms — default: 1500 — How long the producer waits for acks.
+- compression_codec - default: none - The codec the producer uses to compress messages.
 
 See also [Poseidon::Producer](http://www.rubydoc.info/github/bpot/poseidon/Poseidon/Producer) for more detailed documentation about Poseidon.
 

--- a/fluent-plugin-kafka.gemspec
+++ b/fluent-plugin-kafka.gemspec
@@ -19,4 +19,5 @@ Gem::Specification.new do |gem|
   gem.add_dependency 'yajl-ruby'
   gem.add_dependency 'msgpack'
   gem.add_dependency 'zookeeper'
+  gem.add_dependency 'snappy'
 end

--- a/lib/fluent/plugin/out_kafka.rb
+++ b/lib/fluent/plugin/out_kafka.rb
@@ -19,6 +19,7 @@ class Fluent::KafkaOutput < Fluent::Output
   config_param :max_send_retries, :integer, :default => 3
   config_param :required_acks, :integer, :default => 0
   config_param :ack_timeout_ms, :integer, :default => 1500
+  config_param :compression_codec, :string, :default => 'none'
 
   attr_accessor :output_data_type
   attr_accessor :field_separator
@@ -37,7 +38,7 @@ class Fluent::KafkaOutput < Fluent::Output
     end
     begin
       if @seed_brokers.length > 0
-        @producer = Poseidon::Producer.new(@seed_brokers, @client_id, :max_send_retries => @max_send_retries, :required_acks => @required_acks, :ack_timeout_ms => @ack_timeout_ms)
+        @producer = Poseidon::Producer.new(@seed_brokers, @client_id, :max_send_retries => @max_send_retries, :required_acks => @required_acks, :ack_timeout_ms => @ack_timeout_ms, :compression_codec => @compression_codec.to_sym)
         log.info "initialized producer #{@client_id}"
       else
         log.warn "No brokers found on Zookeeper"
@@ -55,6 +56,9 @@ class Fluent::KafkaOutput < Fluent::Output
     else
       @seed_brokers = @brokers.match(",").nil? ? [@brokers] : @brokers.split(",")
       log.info "brokers has been set directly: #{@seed_brokers}"
+    end
+    if @compression_codec == 'snappy'
+      require 'snappy'
     end
     case @output_data_type
     when 'json'

--- a/lib/fluent/plugin/out_kafka_buffered.rb
+++ b/lib/fluent/plugin/out_kafka_buffered.rb
@@ -21,6 +21,7 @@ class Fluent::KafkaOutputBuffered < Fluent::BufferedOutput
   config_param :max_send_retries, :integer, :default => 3
   config_param :required_acks, :integer, :default => 0
   config_param :ack_timeout_ms, :integer, :default => 1500
+  config_param :compression_codec, :string, :default => 'none'
 
   attr_accessor :output_data_type
   attr_accessor :field_separator
@@ -43,7 +44,7 @@ class Fluent::KafkaOutputBuffered < Fluent::BufferedOutput
     end
     begin
       if @seed_brokers.length > 0
-        @producer = Poseidon::Producer.new(@seed_brokers, @client_id, :max_send_retries => @max_send_retries, :required_acks => @required_acks, :ack_timeout_ms => @ack_timeout_ms)
+        @producer = Poseidon::Producer.new(@seed_brokers, @client_id, :max_send_retries => @max_send_retries, :required_acks => @required_acks, :ack_timeout_ms => @ack_timeout_ms, :compression_codec => @compression_codec.to_sym)
         log.info "initialized producer #{@client_id}"
       else
         log.warn "No brokers found on Zookeeper"
@@ -62,7 +63,9 @@ class Fluent::KafkaOutputBuffered < Fluent::BufferedOutput
       @seed_brokers = @brokers.match(",").nil? ? [@brokers] : @brokers.split(",")
       log.info "brokers has been set directly: #{@seed_brokers}"
     end
-
+    if @compression_codec == 'snappy'
+      require 'snappy'
+    end
     case @output_data_type
     when 'json'
       require 'yajl'


### PR DESCRIPTION
To support Kafka compression in out_kafka and out_kafka_bufferd, add a new configuration parameter `compression_codec` and pass the value to Poseidon's producers.