### PR TITLE
Add formatter plugin support by calling formatter as a fallback for unknown output_data_type

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Or install it yourself as:
       zookeeper           <zookeeper_host>:<zookeeper_port> # Set brokers via Zookeeper
 
       default_topic       <output topic>
-      output_data_type    (json|ltsv|msgpack|attr:<record name>)
+      output_data_type    (json|ltsv|msgpack|attr:<record name>|<formatter name>)
       output_include_tag  (true|false) :default => false
       output_include_time (true|false) :default => false
       max_send_retries    (integer)    :default => 3
@@ -77,7 +77,7 @@ Install snappy module before you use snappy compression.
       default_topic       <output topic>
       flush_interval      <flush interval (sec) :default => 60>
       buffer_type         (file|memory)
-      output_data_type    (json|ltsv|msgpack|attr:<record name>)
+      output_data_type    (json|ltsv|msgpack|attr:<record name>|<formatter name>)
       output_include_tag  (true|false) :default => false
       output_include_time (true|false) :default => false
       max_send_retries    (integer)    :default => 3


### PR DESCRIPTION
The out_kafka and out_kafka_buffered plugins have their own implementations for multiple output formats (w/ `output_data_type` option), but not have supports for Fluentd formatter plugins.

To support formatter plugins, make output plugins create formatter plugin instance and call its `format` method when unknown value is passed at `output_data_type`. 

For example, when the following configuration is passed, the output plugin uses `CsvFormatter` plugin to format the output data.
```
output_data_type csv
fields message
force_quotes false
```

This change has a potential to break backward compatibilities if the user already passes the unknown value to `output_data_type`.