### PR TITLE
Create a hash for input text message

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ Or install it yourself as:
       port   <broker port: default=9092>
       topics <listening topics(separate with comma',')>
       format <input text type (text|json|ltsv|msgpack)>
+      message_key <key (Optional, for text format only, default is message)>
       add_prefix <tag prefix (Optional)>
       add_suffix <tag suffix (Optional)>
       max_bytes           (integer)    :default => nil (Use default of Poseidon)


### PR DESCRIPTION
Should create a hash when input record is in plain text, otherwise the record
will be discarded by output plugins.  This was found in our use case: extract
plain text messages from kafka and output to elasticsearch.

See also: [fluentd/fluentd/issues/664](https://github.com/fluent/fluentd/issues/664#issuecomment-135394548).