### PR TITLE
Close producer connection when refresh producer

### DIFF
--- a/lib/fluent/plugin/out_kafka.rb
+++ b/lib/fluent/plugin/out_kafka.rb
@@ -50,6 +50,7 @@ DESC
         broker = Yajl.load(z.get(:path => "/brokers/ids/#{id}")[:data])
         @seed_brokers.push("#{broker['host']}:#{broker['port']}")
       end
+      z.close
       log.info "brokers has been refreshed via Zookeeper: #{@seed_brokers}"
     end
     begin
@@ -153,6 +154,7 @@ DESC
       end
     rescue Exception => e
       log.warn("Send exception occurred: #{e}")
+      @producer.close if @producer
       refresh_producer()
       raise e
     end

--- a/lib/fluent/plugin/out_kafka_buffered.rb
+++ b/lib/fluent/plugin/out_kafka_buffered.rb
@@ -60,6 +60,7 @@ DESC
         broker = Yajl.load(z.get(:path => "/brokers/ids/#{id}")[:data])
         @seed_brokers.push("#{broker['host']}:#{broker['port']}")
       end
+      z.close
       log.info "brokers has been refreshed via Zookeeper: #{@seed_brokers}"
     end
     begin
@@ -176,6 +177,7 @@ DESC
     end
   rescue Exception => e
     log.warn "Send exception occurred: #{e}"
+    @producer.close if @producer
     refresh_producer()
     # Raise exception to retry sendind messages
     raise e


### PR DESCRIPTION
I find the issue #38 .
It seems that new producer is created without closing old producer connection.
This PR is closing producer connection when refresh producer.