### PR TITLE
Add time_format option

### DIFF
--- a/lib/fluent/plugin/out_kafka.rb
+++ b/lib/fluent/plugin/out_kafka.rb
@@ -33,6 +33,8 @@ DESC
   config_param :compression_codec, :string, :default => 'none',
                :desc => "The codec the producer uses to compress messages."
 
+  config_param :time_format, :string, :default => nil
+
   attr_accessor :output_data_type
   attr_accessor :field_separator
 
@@ -143,7 +145,13 @@ DESC
     begin
       chain.next
       es.each do |time,record|
-        record['time'] = time if @output_include_time
+        if @output_include_time
+          if @time_format
+            record['time'] = Time.at(time).strftime(@time_format)
+          else
+            record['time'] = time
+          end
+        end
         record['tag'] = tag if @output_include_tag
         topic = record['topic'] || self.default_topic || tag
         partition_key = record['partition_key'] || @default_partition_key

--- a/lib/fluent/plugin/out_kafka_buffered.rb
+++ b/lib/fluent/plugin/out_kafka_buffered.rb
@@ -43,6 +43,8 @@ The codec the producer uses to compress messages.
 Supported codecs: (none|gzip|snappy)
 DESC
 
+  config_param :time_format, :string, :default => nil
+
   attr_accessor :output_data_type
   attr_accessor :field_separator
 
@@ -146,7 +148,14 @@ DESC
     messages_bytes = 0
     begin
       chunk.msgpack_each { |tag, time, record|
-        record['time'] = time if @output_include_time
+        if @output_include_time
+          if @time_format
+            record['time'] = Time.at(time).strftime(@time_format)
+          else
+            record['time'] = time
+          end
+        end
+
         record['tag'] = tag if @output_include_tag
         topic = record['topic'] || @default_topic || tag
         partition_key = record['partition_key'] || @default_partition_key


### PR DESCRIPTION
- I want to add the `time_format` option. Because it does not use only unixtime.

```
time_format %Y-%m-%dT%H:%M:%S%z
```