### PR TITLE
Adopt v0.14

### DIFF
--- a/fluent-plugin-kafka.gemspec
+++ b/fluent-plugin-kafka.gemspec
@@ -13,6 +13,7 @@ Gem::Specification.new do |gem|
   gem.name          = "fluent-plugin-kafka"
   gem.require_paths = ["lib"]
   gem.version = '0.1.4'
+  gem.add_development_dependency 'test-unit'
   gem.add_dependency 'fluentd'
   gem.add_dependency 'poseidon_cluster'
   gem.add_dependency 'ltsv'

--- a/lib/fluent/plugin/in_kafka.rb
+++ b/lib/fluent/plugin/in_kafka.rb
@@ -84,6 +84,7 @@ class KafkaInput < Input
   end
 
   def start
+    super
     @loop = Coolio::Loop.new
     opt = {}
     opt[:max_bytes] = @max_bytes if @max_bytes
@@ -119,6 +120,7 @@ class KafkaInput < Input
   def shutdown
     @loop.stop
     @zookeeper.close! if @zookeeper
+    super
   end
 
   def run

--- a/lib/fluent/plugin/in_kafka.rb
+++ b/lib/fluent/plugin/in_kafka.rb
@@ -1,3 +1,4 @@
+require 'fluent/input'
 module Fluent
 
 class KafkaInput < Input

--- a/lib/fluent/plugin/in_kafka_group.rb
+++ b/lib/fluent/plugin/in_kafka_group.rb
@@ -76,6 +76,7 @@ class KafkaGroupInput < Input
   end
 
   def start
+    super
     @loop = Coolio::Loop.new
     opt = {}
     opt[:max_bytes] = @max_bytes if @max_bytes
@@ -96,6 +97,7 @@ class KafkaGroupInput < Input
 
   def shutdown
     @loop.stop
+    super
   end
 
   def run

--- a/lib/fluent/plugin/in_kafka_group.rb
+++ b/lib/fluent/plugin/in_kafka_group.rb
@@ -1,3 +1,4 @@
+require 'fluent/input'
 module Fluent
 
 class KafkaGroupInput < Input


### PR DESCRIPTION
Hi, I've tried to adopt Fluentd v0.14.

I've found that there are several problems and I fixed them.

* missing development dependency of test-unit gem
* missing `fluent/input` require
* sometimes missing calling `super` in `#start` and `#shutdown`