### PR TITLE
Use ruby-kafka

### DIFF
--- a/fluent-plugin-kafka.gemspec
+++ b/fluent-plugin-kafka.gemspec
@@ -20,4 +20,5 @@ Gem::Specification.new do |gem|
   gem.add_dependency 'yajl-ruby'
   gem.add_dependency 'msgpack'
   gem.add_dependency 'zookeeper'
+  gem.add_dependency 'ruby-kafka', '~> 0.3.2'
 end

--- a/lib/fluent/plugin/out_kafka_buffered.rb
+++ b/lib/fluent/plugin/out_kafka_buffered.rb
@@ -52,7 +52,7 @@ DESC
                :desc => "Number of times to retry sending of messages to a leader."
   config_param :required_acks, :integer, :default => 0,
                :desc => "The number of acks required per request."
-  config_param :ack_timeout, :integer, :default => nil,
+  config_param :ack_timeout, :time, :default => nil,
                :desc => "How long the producer waits for acks."
   config_param :compression_codec, :string, :default => nil,
                :desc => <<-DESC

--- a/lib/fluent/plugin/out_kafka_buffered.rb
+++ b/lib/fluent/plugin/out_kafka_buffered.rb
@@ -203,7 +203,7 @@ DESC
 
         record_buf = @formatter_proc.call(tag, time, record)
         record_buf_bytes = record_buf.bytesize
-        if messages > 0 and messages_bytes + record_buf_bytes > @kafka_agg_max_bytes
+        if (messages > 0) and (messages_bytes + record_buf_bytes > @kafka_agg_max_bytes)
           log.on_trace { log.trace("#{messages} messages send.") }
           producer.deliver_messages
           messages = 0

--- a/lib/fluent/plugin/out_kafka_buffered.rb
+++ b/lib/fluent/plugin/out_kafka_buffered.rb
@@ -43,7 +43,7 @@ DESC
   config_param :ssl_ca_cert, :string, :default => nil,
                :desc => "a PEM encoded CA cert to use with and SSL connection."
   config_param :ssl_client_cert, :string, :default => nil,
-               :desc => " PEM encoded client cert to use with and SSL connection. Must be used in combination with ssl_client_cert_key."
+               :desc => "a PEM encoded client cert to use with and SSL connection. Must be used in combination with ssl_client_cert_key."
   config_param :ssl_client_cert_key, :string, :default => nil,
                :desc => "a PEM encoded client cert key to use with and SSL connection. Must be used in combination with ssl_client_cert."
 
@@ -113,7 +113,7 @@ DESC
     end
 
     if conf['ack_timeout_ms']
-      log.warn "'ack_timeout_ms' parameter is removed. Use second unit 'ack_timeout' instead"
+      log.warn "'ack_timeout_ms' parameter is deprecated. Use second unit 'ack_timeout' instead"
       @ack_timeout = conf['ack_timeout_ms'].to_i / 1000
     end
 

--- a/lib/fluent/plugin/out_kafka_buffered.rb
+++ b/lib/fluent/plugin/out_kafka_buffered.rb
@@ -1,10 +1,15 @@
 # encode: utf-8
+
 class Fluent::KafkaOutputBuffered < Fluent::BufferedOutput
   Fluent::Plugin.register_output('kafka_buffered', self)
 
   def initialize
     super
-    require 'poseidon'
+
+    require 'kafka'
+
+    @kafka = nil
+    @producer = nil
   end
 
   config_param :brokers, :string, :default => 'localhost:9092',
@@ -30,19 +35,19 @@ Supported format: (json|ltsv|msgpack|attr:<record name>|<formatter name>)
 DESC
   config_param :output_include_tag, :bool, :default => false
   config_param :output_include_time, :bool, :default => false
-  config_param :kafka_agg_max_bytes, :size, :default => 4*1024  #4k
+  config_param :kafka_agg_max_bytes, :size, :default => 4*1024*1024  #4k
 
   # poseidon producer options
-  config_param :max_send_retries, :integer, :default => 3,
+  config_param :max_send_retries, :integer, :default => 1,
                :desc => "Number of times to retry sending of messages to a leader."
   config_param :required_acks, :integer, :default => 0,
                :desc => "The number of acks required per request."
-  config_param :ack_timeout_ms, :integer, :default => 1500,
+  config_param :ack_timeout, :integer, :default => nil,
                :desc => "How long the producer waits for acks."
-  config_param :compression_codec, :string, :default => 'none',
+  config_param :compression_codec, :string, :default => nil,
                :desc => <<-DESC
 The codec the producer uses to compress messages.
-Supported codecs: (none|gzip|snappy)
+Supported codecs: (gzip|snappy)
 DESC
 
   config_param :time_format, :string, :default => nil
@@ -53,8 +58,6 @@ DESC
   unless method_defined?(:log)
     define_method("log") { $log }
   end
-
-  @seed_brokers = []
 
   def refresh_producer()
     if @zookeeper
@@ -69,7 +72,12 @@ DESC
     end
     begin
       if @seed_brokers.length > 0
-        @producer = Poseidon::Producer.new(@seed_brokers, @client_id, :max_send_retries => @max_send_retries, :required_acks => @required_acks, :ack_timeout_ms => @ack_timeout_ms, :compression_codec => @compression_codec.to_sym)
+        @kafka = Kafka.new(seed_brokers: @seed_brokers, client_id: @client_id)
+        producer_opts = {max_retries: @max_send_retries, required_acks: @required_acks,
+                         max_buffer_size: @buffer.buffer_chunk_limit / 10, max_buffer_bytesize: @buffer.buffer_chunk_limit * 2}
+        producer_opts[:ack_timeout] = @ack_timeout if @ack_timeout
+        producer_opts[:compression_codec] = @compression_codec.to_sym if @compression_codec
+        @producer = @kafka.producer(producer_opts)
         log.info "initialized producer #{@client_id}"
       else
         log.warn "No brokers found on Zookeeper"
@@ -81,15 +89,17 @@ DESC
 
   def configure(conf)
     super
+
     if @zookeeper
       require 'zookeeper'
-      require 'yajl'
     else
       @seed_brokers = @brokers.match(",").nil? ? [@brokers] : @brokers.split(",")
       log.info "brokers has been set directly: #{@seed_brokers}"
     end
-    if @compression_codec == 'snappy'
-      require 'snappy'
+
+    if conf['ack_timeout_ms']
+      log.warn "'ack_timeout_ms' parameter is removed. Use second unit 'ack_timeout' instead"
+      @ack_timeout = conf['ack_timeout_ms'].to_i / 1000
     end
 
     @f_separator = case @field_separator
@@ -109,10 +119,18 @@ DESC
 
   def shutdown
     super
+    shutdown_producer
   end
 
   def format(tag, time, record)
     [tag, time, record].to_msgpack
+  end
+
+  def shutdown_producer
+    if @producer
+      @producer.shutdown
+      @producer = nil
+    end
   end
 
   def setup_formatter(conf)
@@ -146,7 +164,7 @@ DESC
   def write(chunk)
     records_by_topic = {}
     bytes_by_topic = {}
-    messages = []
+    messages = 0
     messages_bytes = 0
     begin
       chunk.msgpack_each { |tag, time, record|
@@ -167,28 +185,29 @@ DESC
 
         record_buf = @formatter_proc.call(tag, time, record)
         record_buf_bytes = record_buf.bytesize
-        if messages.length > 0 and messages_bytes + record_buf_bytes > @kafka_agg_max_bytes
-          log.on_trace { log.trace("#{messages.length} messages send.") }
-          @producer.send_messages(messages)
-          messages = []
+        if messages > 0 and messages_bytes + record_buf_bytes > @kafka_agg_max_bytes
+          log.on_trace { log.trace("#{messages} messages send.") }
+          @producer.deliver_messages
+          messages = 0
           messages_bytes = 0
         end
         log.on_trace { log.trace("message will send to #{topic} with key: #{partition_key} and value: #{record_buf}.") }
-        messages << Poseidon::MessageToSend.new(topic, record_buf, partition_key)
+        messages += 1
+        @producer.produce(record_buf, topic: topic, partition_key: partition_key)
         messages_bytes += record_buf_bytes
 
         records_by_topic[topic] += 1
         bytes_by_topic[topic] += record_buf_bytes
       }
-      if messages.length > 0
-        log.trace("#{messages.length} messages send.")
-        @producer.send_messages(messages)
+      if messages > 0
+        log.trace("#{messages} messages send.")
+        @producer.deliver_messages
       end
       log.debug "(records|bytes) (#{records_by_topic}|#{bytes_by_topic})"
     end
   rescue Exception => e
     log.warn "Send exception occurred: #{e}"
-    @producer.close if @producer
+    shutdown_producer
     refresh_producer()
     # Raise exception to retry sendind messages
     raise e


### PR DESCRIPTION
Use ruby-kafka for kafka v0.9 or v0.10 support.

- [x] Make plugin thread-safe with `num_threads`
- [x] Add new features like TLS
- [x] Check performance

In this PR, I plan to update only kafka_buffered.
We need stable consumer API for replacing input plugins.