### PR TITLE
Removed the `zookeeper_path` option from the input config.

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,6 @@ See also [Poseidon::PartitionConsumer](http://www.rubydoc.info/github/bpot/posei
       @type   kafka_group
       brokers <list of broker-host:port, separate with comma, must set>
       zookeepers <list of broker-host:port, separate with comma, must set>
-      zookeeper_path <broker path in zookeeper> :default => /brokers/ids # Set path in zookeeper for brokers
       consumer_group <consumer group name, must set>
       topics <listening topics(separate with comma',')>
       format <input text type (text|json|ltsv|msgpack)>


### PR DESCRIPTION
The input plugin currently doesn't support `zookeeper_path`.  This was a source of confusion when trying out the plugin.