### PR TITLE
Update ruby-kafka dependency to v0.3.9

### DIFF
--- a/fluent-plugin-kafka.gemspec
+++ b/fluent-plugin-kafka.gemspec
@@ -20,5 +20,5 @@ Gem::Specification.new do |gem|
   gem.add_dependency 'yajl-ruby'
   gem.add_dependency 'msgpack'
   gem.add_dependency 'zookeeper'
-  gem.add_dependency 'ruby-kafka', '~> 0.3.2'
+  gem.add_dependency 'ruby-kafka', '~> 0.3.9'
 end


### PR DESCRIPTION
ruby-kafka 0.3.9 improves producer performance so updating lower version is better.