### PR TITLE
Extend Kafka::Producer to improve out_kafka_buffered

### DIFF
--- a/lib/fluent/plugin/kafka_producer_ext.rb
+++ b/lib/fluent/plugin/kafka_producer_ext.rb
@@ -1,0 +1,24 @@
+require 'kafka/producer'
+
+module Kafka
+  class Producer
+    def produce2(value, key: nil, topic:, partition: nil, partition_key: nil)
+      create_time = Time.now
+
+      message = PendingMessage.new(
+        value,
+        key,
+        topic,
+        partition,
+        partition_key,
+        create_time,
+        key.to_s.bytesize + value.to_s.bytesize
+      )
+
+      @target_topics.add(topic)
+      @pending_message_queue.write(message)
+
+      nil
+    end
+  end
+end

--- a/lib/fluent/plugin/out_kafka_buffered.rb
+++ b/lib/fluent/plugin/out_kafka_buffered.rb
@@ -8,6 +8,7 @@ class Fluent::KafkaOutputBuffered < Fluent::BufferedOutput
     super
 
     require 'kafka'
+    require 'fluent/plugin/kafka_producer_ext'
 
     @kafka = nil
     @producers = {}
@@ -126,8 +127,7 @@ DESC
 
     @formatter_proc = setup_formatter(conf)
 
-    @producer_opts = {max_retries: @max_send_retries, required_acks: @required_acks,
-                      max_buffer_size: @buffer.buffer_chunk_limit / 10, max_buffer_bytesize: @buffer.buffer_chunk_limit * 2}
+    @producer_opts = {max_retries: @max_send_retries, required_acks: @required_acks}
     @producer_opts[:ack_timeout] = @ack_timeout if @ack_timeout
     @producer_opts[:compression_codec] = @compression_codec.to_sym if @compression_codec
   end
@@ -233,7 +233,7 @@ DESC
         end
         log.on_trace { log.trace("message will send to #{topic} with key: #{partition_key} and value: #{record_buf}.") }
         messages += 1
-        producer.produce(record_buf, topic: topic, partition_key: partition_key)
+        producer.produce2(record_buf, topic: topic, partition_key: partition_key)
         messages_bytes += record_buf_bytes
 
         records_by_topic[topic] += 1


### PR DESCRIPTION
This approach has two merits

- Improve CPU / memory usage by avoiding unnecessary object allocation
- Skip buffer size check

Output plugin has own buffer check mechanizm so we don't need buffer size check in ruby-kafka side.
Skipping it resolves https://github.com/htgc/fluent-plugin-kafka/issues/61 together.
Producer API is now stable so extend Producer seems acceptable for me.