### PR TITLE
Replace poseidon with ruby-kafka in input pugins

### DIFF
--- a/fluent-plugin-kafka.gemspec
+++ b/fluent-plugin-kafka.gemspec
@@ -14,10 +14,9 @@ Gem::Specification.new do |gem|
   gem.require_paths = ["lib"]
   gem.version = '0.2.2'
   gem.add_dependency "fluentd", [">= 0.10.58", "< 2"]
-  gem.add_dependency 'poseidon_cluster'
   gem.add_dependency 'ltsv'
   gem.add_dependency 'zookeeper'
-  gem.add_dependency 'ruby-kafka', '~> 0.3.9'
+  gem.add_dependency 'ruby-kafka', '~> 0.3.11'
   gem.add_development_dependency "rake", ">= 0.9.2"
   gem.add_development_dependency "test-unit", ">= 3.0.8"
 end

--- a/lib/fluent/plugin/in_kafka.rb
+++ b/lib/fluent/plugin/in_kafka.rb
@@ -55,7 +55,6 @@ class KafkaInput < Input
   def initialize
     super
     require 'kafka'
-    require 'zookeeper'
   end
 
   def configure(conf)
@@ -185,8 +184,8 @@ class KafkaInput < Input
 
   def run
     @loop.run
-  rescue
-    $log.error "unexpected error", :error=>$!.to_s
+  rescue => e
+    $log.error "unexpected error", :error => e.to_s
     $log.error_backtrace
   end
 
@@ -216,9 +215,9 @@ class KafkaInput < Input
 
     def on_timer
       @callback.call
-    rescue
+    rescue => e
       # TODO log?
-      $log.error $!.to_s
+      $log.error e.to_s
       $log.error_backtrace
     end
 

--- a/lib/fluent/plugin/in_kafka.rb
+++ b/lib/fluent/plugin/in_kafka.rb
@@ -8,10 +8,12 @@ class KafkaInput < Input
                :desc => "Supported format: (json|text|ltsv|msgpack)"
   config_param :message_key, :string, :default => 'message',
                :desc => "For 'text' format only."
-  config_param :host, :string, :default => 'localhost',
+  config_param :host, :string, :default => nil,
                :desc => "Broker host"
-  config_param :port, :integer, :default => 9092,
+  config_param :port, :integer, :default => nil,
                :desc => "Broker port"
+  config_param :brokers, :string, :default => 'localhost:9092',
+               :desc => "List of broker-host:port, separate with comma, must set."
   config_param :interval, :integer, :default => 1, # seconds
                :desc => "Interval (Unit: seconds)"
   config_param :topics, :string, :default => nil,
@@ -30,11 +32,13 @@ class KafkaInput < Input
   config_param :offset_zookeeper, :string, :default => nil
   config_param :offset_zk_root_node, :string, :default => '/fluent-plugin-kafka'
 
-  # poseidon PartitionConsumer options
+  # Kafka#fetch_messages options
   config_param :max_bytes, :integer, :default => nil,
                :desc => "Maximum number of bytes to fetch."
-  config_param :max_wait_ms, :integer, :default => nil,
+  config_param :max_wait_time, :integer, :default => nil,
                :desc => "How long to block until the server sends us data."
+  config_param :max_wait_ms, :integer, :default => nil,
+               :desc => "Deprecated. How long to block until the server sends us data."
   config_param :min_bytes, :integer, :default => nil,
                :desc => "Smallest amount of data the server should send us."
   config_param :socket_timeout_ms, :integer, :default => nil,
@@ -46,7 +50,7 @@ class KafkaInput < Input
 
   def initialize
     super
-    require 'poseidon'
+    require 'kafka'
     require 'zookeeper'
   end
 
@@ -73,6 +77,27 @@ class KafkaInput < Input
       raise ConfigError, "kafka: 'topics' or 'topic element' is a require parameter"
     end
 
+    # For backward compatibility
+    @brokers = case
+               when @host && @port
+                 ["#{@host}:#{@port}"]
+               when @host
+                 ["#{@host}:9092"]
+               when @port
+                 ["localhost:#{@port}"]
+               else
+                 @brokers
+               end
+
+    if conf['max_wait_ms']
+      log.warn "'max_wait_ms' parameter is deprecated. Use second unit 'max_wait_time' instead"
+      @max_wait_time = conf['max_wait_ms'].to_i / 1000
+    end
+
+    @max_wait_time = @interval if @max_wait_time.nil?
+
+    require 'zookeeper' if @offset_zookeeper
+
     case @format
     when 'json'
       require 'yajl'
@@ -88,19 +113,17 @@ class KafkaInput < Input
     @loop = Coolio::Loop.new
     opt = {}
     opt[:max_bytes] = @max_bytes if @max_bytes
-    opt[:max_wait_ms] = @max_wait_ms if @max_wait_ms
+    opt[:max_wait_time] = @max_wait_time if @max_wait_time
     opt[:min_bytes] = @min_bytes if @min_bytes
-    opt[:socket_timeout_ms] = @socket_timeout_ms if @socket_timeout_ms
 
+    @kafka = Kafka.new(seed_brokers: @brokers, client_id: @client_id)
     @zookeeper = Zookeeper.new(@offset_zookeeper) if @offset_zookeeper
 
     @topic_watchers = @topic_list.map {|topic_entry|
       offset_manager = OffsetManager.new(topic_entry, @zookeeper, @offset_zk_root_node) if @offset_zookeeper
       TopicWatcher.new(
         topic_entry,
-        @host,
-        @port,
-        @client_id,
+        @kafka,
         interval,
         @format,
         @message_key,
@@ -131,11 +154,9 @@ class KafkaInput < Input
   end
 
   class TopicWatcher < Coolio::TimerWatcher
-    def initialize(topic_entry, host, port, client_id, interval, format, message_key, add_offset_in_record, add_prefix, add_suffix, offset_manager, router, options={})
+    def initialize(topic_entry, kafka, interval, format, message_key, add_offset_in_record, add_prefix, add_suffix, offset_manager, router, options={})
       @topic_entry = topic_entry
-      @host = host
-      @port = port
-      @client_id = client_id
+      @kafka = kafka
       @callback = method(:consume)
       @format = format
       @message_key = message_key
@@ -150,7 +171,10 @@ class KafkaInput < Input
       if @topic_entry.offset == -1 && offset_manager
         @next_offset = offset_manager.next_offset
       end
-      @consumer = create_consumer(@next_offset)      
+      @fetch_args = {
+        topic: @topic_entry.topic,
+        partition: @topic_entry.partition,
+      }.merge(@options)
 
       super(interval, true)
     end
@@ -164,16 +188,18 @@ class KafkaInput < Input
     end
 
     def consume
+      offset = @next_offset
+      @fetch_args[:offset] = offset
+      messages = @kafka.fetch_messages(@fetch_args)
+
+      return if messages.size.zero?
+
       es = MultiEventStream.new
       tag = @topic_entry.topic
       tag = @add_prefix + "." + tag if @add_prefix
       tag = tag + "." + @add_suffix if @add_suffix
 
-      if @offset_manager && @consumer.next_offset != @next_offset
-        @consumer = create_consumer(@next_offset)
-      end
-
-      @consumer.fetch.each { |msg|
+      messages.each { |msg|
         begin
           msg_record = parse_line(msg.value)
           msg_record = decorate_offset(msg_record, msg.offset) if @add_offset_in_record
@@ -183,29 +209,16 @@ class KafkaInput < Input
           $log.debug_backtrace
         end
       }
+      offset = messages.last.offset + 1
 
       unless es.empty?
         @router.emit_stream(tag, es)
 
         if @offset_manager
-          next_offset = @consumer.next_offset
-          @offset_manager.save_offset(next_offset)
-          @next_offset = next_offset
+          @offset_manager.save_offset(offset)
         end
+        @next_offset = offset
       end
-    end
-
-    def create_consumer(offset)
-      @consumer.close if @consumer
-      Poseidon::PartitionConsumer.new(
-        @client_id,             # client_id
-        @host,                  # host
-        @port,                  # port
-        @topic_entry.topic,     # topic
-        @topic_entry.partition, # partition
-        offset,                 # offset
-        @options                # options
-      )
     end
 
     def parse_line(record)

--- a/lib/fluent/plugin/in_kafka.rb
+++ b/lib/fluent/plugin/in_kafka.rb
@@ -39,8 +39,6 @@ class KafkaInput < Input
                :desc => "Maximum number of bytes to fetch."
   config_param :max_wait_time, :integer, :default => nil,
                :desc => "How long to block until the server sends us data."
-  config_param :max_wait_ms, :integer, :default => nil,
-               :desc => "Deprecated. How long to block until the server sends us data."
   config_param :min_bytes, :integer, :default => nil,
                :desc => "Smallest amount of data the server should send us."
   config_param :socket_timeout_ms, :integer, :default => nil,

--- a/lib/fluent/plugin/in_kafka.rb
+++ b/lib/fluent/plugin/in_kafka.rb
@@ -177,6 +177,8 @@ class KafkaInput < Input
   def shutdown
     @loop.stop
     @zookeeper.close! if @zookeeper
+    @thread.join
+    @kafka.close
     super
   end
 

--- a/lib/fluent/plugin/in_kafka_group.rb
+++ b/lib/fluent/plugin/in_kafka_group.rb
@@ -24,8 +24,6 @@ class KafkaGroupInput < Input
   # Kafka consumer options
   config_param :max_wait_time, :integer, :default => nil,
                :desc => "How long to block until the server sends us data."
-  config_param :max_wait_ms, :integer, :default => nil,
-               :desc => "Deprecated. How long to block until the server sends us data."
   config_param :min_bytes, :integer, :default => nil,
                :desc => "Smallest amount of data the server should send us."
   config_param :session_timeout, :integer, :default => nil,

--- a/lib/fluent/plugin/in_kafka_group.rb
+++ b/lib/fluent/plugin/in_kafka_group.rb
@@ -140,8 +140,8 @@ class KafkaGroupInput < Input
         router.emit_stream(tag, es)
       end
     }
-  rescue
-    $log.error "unexpected error", :error=>$!.to_s
+  rescue => e
+    $log.error "unexpected error", :error => e.to_s
     $log.error_backtrace
   end
 end

--- a/lib/fluent/plugin/in_kafka_group.rb
+++ b/lib/fluent/plugin/in_kafka_group.rb
@@ -1,19 +1,16 @@
 require 'fluent/input'
+
 module Fluent
 
 class KafkaGroupInput < Input
   Plugin.register_input('kafka_group', self)
 
-  config_param :brokers, :string,
+  config_param :brokers, :string, :default => 'localhost:9092',
                :desc => "List of broker-host:port, separate with comma, must set."
-  config_param :zookeepers, :string,
-               :desc => "List of broker-host:port, separate with comma, must set."
-  config_param :consumer_group, :string, :default => nil,
+  config_param :consumer_group, :string,
                :desc => "Consumer group name, must set."
   config_param :topics, :string,
                :desc => "Listening topics(separate with comma',')."
-  config_param :interval, :integer, :default => 1, # seconds
-               :desc => "Interval (Unit: seconds)"
   config_param :format, :string, :default => 'json',
                :desc => "Supported format: (json|text|ltsv|msgpack)"
   config_param :message_key, :string, :default => 'message',
@@ -23,15 +20,21 @@ class KafkaGroupInput < Input
   config_param :add_suffix, :string, :default => nil,
                :desc => "Tag suffix (Optional)"
 
-  # poseidon PartitionConsumer options
-  config_param :max_bytes, :integer, :default => nil,
-               :desc => "Maximum number of bytes to fetch."
-  config_param :max_wait_ms, :integer, :default => nil,
+  # Kafka consumer options
+  config_param :max_wait_time, :integer, :default => nil,
                :desc => "How long to block until the server sends us data."
+  config_param :max_wait_ms, :integer, :default => nil,
+               :desc => "Deprecated. How long to block until the server sends us data."
   config_param :min_bytes, :integer, :default => nil,
                :desc => "Smallest amount of data the server should send us."
-  config_param :socket_timeout_ms, :integer, :default => nil,
-               :desc => "How long to wait for reply from server. Should be higher than max_wait_ms."
+  config_param :session_timeout, :integer, :default => nil,
+               :desc => "The number of seconds after which, if a client hasn't contacted the Kafka cluster"
+  config_param :offset_commit_interval, :integer, :default => nil,
+               :desc => "The interval between offset commits, in seconds"
+  config_param :offset_commit_threshold, :integer, :default => nil,
+               :desc => "The number of messages that can be processed before their offsets are committed"
+  config_param :start_from_beginning, :bool, :default => true,
+               :desc => "Whether to start from the beginning of the topic or just subscribe to new messages being produced"
 
   unless method_defined?(:router)
     define_method("router") { Fluent::Engine }
@@ -39,7 +42,7 @@ class KafkaGroupInput < Input
 
   def initialize
     super
-    require 'poseidon_cluster'
+    require 'kafka'
   end
 
   def _config_to_array(config)
@@ -54,125 +57,86 @@ class KafkaGroupInput < Input
 
   def configure(conf)
     super
-    @broker_list = _config_to_array(@brokers)
-    @zookeeper_list = _config_to_array(@zookeepers)
-    @topic_list = _config_to_array(@topics)
 
-    unless @consumer_group
-      raise ConfigError, "kafka_group: 'consumer_group' is a required parameter"
+    $log.info "Will watch for topics #{@topics} at brokers " \
+              "#{@brokers} and '#{@consumer_group}' group"
+
+    @topics = _config_to_array(@topics)
+
+    if conf['max_wait_ms']
+      log.warn "'max_wait_ms' parameter is deprecated. Use second unit 'max_wait_time' instead"
+      @max_wait_time = conf['max_wait_ms'].to_i / 1000
     end
-    $log.info "Will watch for topics #{@topic_list} at brokers " \
-              "#{@broker_list}, zookeepers #{@zookeeper_list} and group " \
-              "'#{@consumer_group}'"
 
+    @parser_proc = setup_parser
+  end
+
+  def setup_parser
     case @format
     when 'json'
       require 'yajl'
+      Proc.new { |msg| Yajl::Parser.parse(msg.value) }
     when 'ltsv'
       require 'ltsv'
+      Proc.new { |msg| LTSV.parse(msg.value).first }
     when 'msgpack'
       require 'msgpack'
+      Proc.new { |msg| MessagePack.unpack(msg.value) }
+    when 'text'
+      Proc.new { |msg| {@message_key => msg.value} }
     end
   end
 
   def start
     super
-    @loop = Coolio::Loop.new
-    opt = {}
-    opt[:max_bytes] = @max_bytes if @max_bytes
-    opt[:max_wait_ms] = @max_wait_ms if @max_wait_ms
-    opt[:min_bytes] = @min_bytes if @min_bytes
-    opt[:socket_timeout_ms] = @socket_timeout_ms if @socket_timeout_ms
 
-    @topic_watchers = @topic_list.map {|topic|
-      TopicWatcher.new(topic, @broker_list, @zookeeper_list, @consumer_group,
-                       interval, @format, @message_key, @add_prefix,
-                       @add_suffix, router, opt)
-    }
-    @topic_watchers.each {|tw|
-      tw.attach(@loop)
+    consumer_opts = {:group_id => @consumer_group}
+    consumer_opts[:session_timeout] = @session_timeout if @session_timeout
+    consumer_opts[:offset_commit_interval] = @offset_commit_interval if @offset_commit_interval
+    consumer_opts[:offset_commit_threshold] = @offset_commit_threshold if @offset_commit_threshold
+
+    @fetch_opts = {}
+    @fetch_opts[:max_wait_time] = @max_wait_time if @max_wait_time
+    @fetch_opts[:min_bytes] = @min_bytes if @min_bytes
+
+    @kafka = Kafka.new(seed_brokers: @brokers)
+    @consumer = @kafka.consumer(consumer_opts)
+    @topics.each { |topic|
+      @consumer.subscribe(topic, start_from_beginning: @start_from_beginning)
     }
     @thread = Thread.new(&method(:run))
   end
 
   def shutdown
-    @loop.stop
+    @consumer.stop
+    @thread.join
+    @kafka.close
     super
   end
 
   def run
-    @loop.run
-  rescue
-    $log.error "unexpected error", :error=>$!.to_s
-    $log.error_backtrace
-  end
-
-  class TopicWatcher < Coolio::TimerWatcher
-    def initialize(topic, broker_list, zookeeper_list, consumer_group,
-                   interval, format, message_key, add_prefix, add_suffix,
-                   router, options)
-      @topic = topic
-      @callback = method(:consume)
-      @format = format
-      @message_key = message_key
-      @add_prefix = add_prefix
-      @add_suffix = add_suffix
-      @router = router
-
-      @consumer = Poseidon::ConsumerGroup.new(
-        consumer_group,
-        broker_list,
-        zookeeper_list,
-        topic,
-        options
-      )
-
-      super(interval, true)
-    end
-
-    def on_timer
-      @callback.call
-    rescue
-        # TODO log?
-        $log.error $!.to_s
-        $log.error_backtrace
-    end
-
-    def consume
+    @consumer.each_batch(@fetch_opts) { |batch|
       es = MultiEventStream.new
-      tag = @topic
+      tag = batch.topic
       tag = @add_prefix + "." + tag if @add_prefix
       tag = tag + "." + @add_suffix if @add_suffix
 
-      @consumer.fetch do |partition, bulk|
-        bulk.each do |msg|
-          begin
-            msg_record = parse_line(msg.value)
-            es.add(Engine.now, msg_record)
-          rescue
-            $log.warn msg_record.to_s, :error=>$!.to_s
-            $log.debug_backtrace
-          end
+      batch.messages.each { |msg|
+        begin
+          es.add(Engine.now, @parser_proc.call(msg))
+        rescue => e
+          $log.warn "parser error in #{batch.topic}/#{batch.partition}", :error => e.to_s, :value => msg.value, :offset => msg.offset
+          $log.debug_backtrace
         end
-      end
+      }
 
       unless es.empty?
-        @router.emit_stream(tag, es)
+        router.emit_stream(tag, es)
       end
-    end
-
-    def parse_line(record)
-      case @format
-      when 'json'
-        Yajl::Parser.parse(record)
-      when 'ltsv'
-        LTSV.parse(record)
-      when 'msgpack'
-        MessagePack.unpack(record)
-      when 'text'
-        {@message_key => record}
-      end
-    end
+    }
+  rescue
+    $log.error "unexpected error", :error=>$!.to_s
+    $log.error_backtrace
   end
 end
 

--- a/lib/fluent/plugin/kafka_plugin_util.rb
+++ b/lib/fluent/plugin/kafka_plugin_util.rb
@@ -1,0 +1,21 @@
+module Fluent
+  module KafkaPluginUtil
+    module SSLSettings
+      def self.included(klass)
+        klass.instance_eval {
+          config_param :ssl_ca_cert, :string, :default => nil,
+                       :desc => "a PEM encoded CA cert to use with and SSL connection."
+          config_param :ssl_client_cert, :string, :default => nil,
+                       :desc => "a PEM encoded client cert to use with and SSL connection. Must be used in combination with ssl_client_cert_key."
+          config_param :ssl_client_cert_key, :string, :default => nil,
+                       :desc => "a PEM encoded client cert key to use with and SSL connection. Must be used in combination with ssl_client_cert."
+        }
+      end
+
+      def read_ssl_file(path)
+        return nil if path.nil?
+        File.read(path)
+      end
+    end
+  end
+end


### PR DESCRIPTION
For supporting recent kafka versions.

Remove several parameters because ruby-kafka consumer approach is different from poseidon.
Note that consumer APIs in ruby-kafka is still alpha so we may hit the problems.
We need tests on several workload.

TODO: Remove zookeeper dependency from gem.