### PR TITLE
test_in_kafka_group: fix flaky test

### DIFF
--- a/test/plugin/test_in_kafka_group.rb
+++ b/test/plugin/test_in_kafka_group.rb
@@ -39,6 +39,7 @@ class KafkaGroupInputTest < Test::Unit::TestCase
   class ConsumeTest < self
     def setup
       @kafka = Kafka.new(["localhost:9092"], client_id: 'kafka')
+      @kafka.create_topic(TOPIC_NAME)
       @producer = @kafka.producer
     end
 
@@ -59,6 +60,7 @@ class KafkaGroupInputTest < Test::Unit::TestCase
       d = create_driver
 
       d.run(expect_records: 1, timeout: 10) do
+        sleep 0.1
         @producer.produce("Hello, fluent-plugin-kafka!", topic: TOPIC_NAME)
         @producer.deliver_messages
       end


### PR DESCRIPTION
Seems `test_in_kafka_group.rb` has flaky test, it causes following error sometimes.

```
$ ruby -I"lib:lib:test" test/plugin/test_in_kafka_group.rb
Loaded suite test/plugin/test_in_kafka_group
Started
E
=========================================================================================================================================================================================================================================================
Error: test_consume(KafkaGroupInputTest::ConsumeTest): NoMethodError: undefined method `[]' for nil
test/plugin/test_in_kafka_group.rb:66:in `test_consume'
     63:         @producer.deliver_messages
     64:       end
     65:       expected = {'message'  => 'Hello, fluent-plugin-kafka!'}
  => 66:       assert_equal expected, d.events[0][2]
     67:     end
     68:   end
     69: end
=========================================================================================================================================================================================================================================================
Finished in 11.063212384 seconds.
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
3 tests, 4 assertions, 0 failures, 1 errors, 0 pendings, 0 omissions, 0 notifications
66.6667% passed
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
0.27 tests/s, 0.36 assertions/s
```

The topic used for testing is automatically created by the message produce with following code.

```ruby
@producer.produce("Hello, fluent-plugin-kafka!", topic: TOPIC_NAME)
@producer.deliver_messages
```

Depending on when it subscribe a topic, it may not have been generated yet, and it seems it cannot consume messages properly.

Therefore, this PR will create the topic in advance and insert a delay to adjust the timing.