### PR TITLE
ci: update baseline of confluent

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -53,10 +53,10 @@ jobs:
     - name: Install confluent-kafka
       run: |
         sudo apt install -V -y gnupg2 wget
-        wget https://packages.confluent.io/deb/7.8/archive.key
+        wget https://packages.confluent.io/deb/7.9/archive.key
         sudo gpg2 --homedir /tmp --no-default-keyring --keyring gnupg-ring:/usr/share/keyrings/confluent-archive-keyring.gpg --import archive.key
         sudo chmod 644 /usr/share/keyrings/confluent-archive-keyring.gpg
-        sudo sh -c 'echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/confluent-archive-keyring.gpg] https://packages.confluent.io/deb/7.8 stable main" > /etc/apt/sources.list.d/confluent.list'
+        sudo sh -c 'echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/confluent-archive-keyring.gpg] https://packages.confluent.io/deb/7.9 stable main" > /etc/apt/sources.list.d/confluent.list'
         sudo apt update
         sudo apt install -y confluent-community-2.13 openjdk-11-jre netcat-openbsd
     - name: unit testing

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -53,10 +53,10 @@ jobs:
     - name: Install confluent-kafka
       run: |
         sudo apt install -V -y gnupg2 wget
-        wget https://packages.confluent.io/deb/6.0/archive.key
+        wget https://packages.confluent.io/deb/7.8/archive.key
         sudo gpg2 --homedir /tmp --no-default-keyring --keyring gnupg-ring:/usr/share/keyrings/confluent-archive-keyring.gpg --import archive.key
         sudo chmod 644 /usr/share/keyrings/confluent-archive-keyring.gpg
-        sudo sh -c 'echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/confluent-archive-keyring.gpg] https://packages.confluent.io/deb/6.0 stable main" > /etc/apt/sources.list.d/confluent.list'
+        sudo sh -c 'echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/confluent-archive-keyring.gpg] https://packages.confluent.io/deb/7.8 stable main" > /etc/apt/sources.list.d/confluent.list'
         sudo apt update
         sudo apt install -y confluent-community-2.13 openjdk-11-jre netcat-openbsd
     - name: unit testing

--- a/ci/prepare-kafka-server.sh
+++ b/ci/prepare-kafka-server.sh
@@ -1,5 +1,7 @@
 #!/bin/sh
 
+set -x
+
 export KAFKA_OPTS=-Dzookeeper.4lw.commands.whitelist=ruok
 /usr/bin/zookeeper-server-start /etc/kafka/zookeeper.properties  &
 N_POLLING=30

--- a/ci/prepare-kafka-server.sh
+++ b/ci/prepare-kafka-server.sh
@@ -30,4 +30,14 @@ while true ; do
 	exit 1
     fi
 done
-/usr/bin/kafka-topics --create --zookeeper localhost:2181 --replication-factor 1 --partitions 1 --topic test
+# kafka-topics --version fails to connect zookeeper here.
+case "$(java -cp "/usr/share/java/kafka/*" kafka.Kafka --version 2>/dev/null)" in
+    7.*)
+        /usr/bin/kafka-topics --create --bootstrap-server localhost:9092 --replication-factor 1 --partitions 1 --topic test
+        ;;
+    *)
+        # Deprecated zookeeper
+        /usr/bin/kafka-topics --create --zookeeper localhost:2181 --replication-factor 1 --partitions 1 --topic test
+        ;;
+esac
+


### PR DESCRIPTION
https://docs.confluent.io/platform/current/installation/versions-interoperability.html#cp-and-apache-ak-compatibility It might be better to update supported one.

EOL of 7.8.x: December 2, 2026.