### PR TITLE
Replace yajl-ruby with the json gem for JSON handling

### DIFF
--- a/lib/fluent/plugin/in_kafka.rb
+++ b/lib/fluent/plugin/in_kafka.rb
@@ -143,9 +143,9 @@ class Fluent::KafkaInput < Fluent::Input
           r
         }
       rescue LoadError
-        require 'yajl'
+        require 'json'
         Proc.new { |msg, te|
-          r = Yajl::Parser.parse(msg.value)
+          r = JSON.parse(msg.value)
           add_offset_in_hash(r, te, msg.offset) if @add_offset_in_record
           r
         }

--- a/lib/fluent/plugin/in_kafka_group.rb
+++ b/lib/fluent/plugin/in_kafka_group.rb
@@ -160,8 +160,8 @@ class Fluent::KafkaGroupInput < Fluent::Input
         Oj.default_options = Fluent::DEFAULT_OJ_OPTIONS
         Proc.new { |msg| Oj.load(msg.value) }
       rescue LoadError
-        require 'yajl'
-        Proc.new { |msg| Yajl::Parser.parse(msg.value) }
+        require 'json'
+        Proc.new { |msg| JSON.parse(msg.value) }
       end
     when 'ltsv'
       require 'ltsv'
@@ -265,7 +265,7 @@ class Fluent::KafkaGroupInput < Fluent::Input
   end
 
   def process_batch_with_record_tag(batch)
-    es = {} 
+    es = {}
     batch.messages.each { |msg|
       begin
         record = @parser_proc.call(msg)
@@ -361,7 +361,7 @@ class Fluent::KafkaGroupInput < Fluent::Input
           if @tag_source == :record
             process_batch_with_record_tag(batch)
           else
-            process_batch(batch) 
+            process_batch(batch)
           end
         }
       rescue ForShutdown

--- a/lib/fluent/plugin/in_rdkafka_group.rb
+++ b/lib/fluent/plugin/in_rdkafka_group.rb
@@ -137,8 +137,8 @@ class Fluent::Plugin::RdKafkaGroupInput < Fluent::Plugin::Input
         Oj.default_options = Fluent::DEFAULT_OJ_OPTIONS
         Proc.new { |msg| Oj.load(msg.payload) }
       rescue LoadError
-        require 'yajl'
-        Proc.new { |msg| Yajl::Parser.parse(msg.payload) }
+        require 'json'
+        Proc.new { |msg| JSON.parse(msg.payload) }
       end
     when 'ltsv'
       require 'ltsv'

--- a/lib/fluent/plugin/out_kafka.rb
+++ b/lib/fluent/plugin/out_kafka.rb
@@ -96,7 +96,7 @@ DESC
       @seed_brokers = []
       z = Zookeeper.new(@zookeeper)
       z.get_children(:path => @zookeeper_path)[:children].each do |id|
-        broker = Yajl.load(z.get(:path => @zookeeper_path + "/#{id}")[:data])
+        broker = JSON.parse(z.get(:path => @zookeeper_path + "/#{id}")[:data])
         if @ssl_client_cert
           @seed_brokers.push(pickup_ssl_endpoint(broker))
         else
@@ -192,8 +192,8 @@ DESC
 
   def setup_formatter(conf)
     if @output_data_type == 'json'
-      require 'yajl'
-      Proc.new { |tag, time, record| Yajl::Encoder.encode(record) }
+      require 'json'
+      Proc.new { |tag, time, record| JSON.generate(record) }
     elsif @output_data_type == 'ltsv'
       require 'ltsv'
       Proc.new { |tag, time, record| LTSV.dump(record) }

--- a/lib/fluent/plugin/out_kafka2.rb
+++ b/lib/fluent/plugin/out_kafka2.rb
@@ -314,8 +314,8 @@ DESC
           Oj.default_options = Fluent::DEFAULT_OJ_OPTIONS
           Proc.new { |tag, time, record| Oj.dump(record) }
         rescue LoadError
-          require 'yajl'
-          Proc.new { |tag, time, record| Yajl::Encoder.encode(record) }
+          require 'json'
+          Proc.new { |tag, time, record| JSON.generate(record) }
         end
       when 'ltsv'
         require 'ltsv'

--- a/lib/fluent/plugin/out_kafka_buffered.rb
+++ b/lib/fluent/plugin/out_kafka_buffered.rb
@@ -119,7 +119,7 @@ DESC
       @seed_brokers = []
       z = Zookeeper.new(@zookeeper)
       z.get_children(:path => @zookeeper_path)[:children].each do |id|
-        broker = Yajl.load(z.get(:path => @zookeeper_path + "/#{id}")[:data])
+        broker = JSON.parse(z.get(:path => @zookeeper_path + "/#{id}")[:data])
         if @ssl_client_cert
           @seed_brokers.push(pickup_ssl_endpoint(broker))
         else
@@ -259,8 +259,8 @@ DESC
         Oj.default_options = Fluent::DEFAULT_OJ_OPTIONS
         Proc.new { |tag, time, record| Oj.dump(record) }
       rescue LoadError
-        require 'yajl'
-        Proc.new { |tag, time, record| Yajl::Encoder.encode(record) }
+        require 'json'
+        Proc.new { |tag, time, record| JSON.generate(record) }
       end
     elsif @output_data_type == 'ltsv'
       require 'ltsv'

--- a/lib/fluent/plugin/out_rdkafka.rb
+++ b/lib/fluent/plugin/out_rdkafka.rb
@@ -228,8 +228,8 @@ DESC
         Oj.default_options = Fluent::DEFAULT_OJ_OPTIONS
         Proc.new { |tag, time, record| Oj.dump(record) }
       rescue LoadError
-        require 'yajl'
-        Proc.new { |tag, time, record| Yajl::Encoder.encode(record) }
+        require 'json'
+        Proc.new { |tag, time, record| JSON.generate(record) }
       end
     elsif @output_data_type == 'ltsv'
       require 'ltsv'


### PR DESCRIPTION
Since the yajl-ruby gem depends on a deprecated Ruby C API, it cannot be installed with Ruby 4.1.